### PR TITLE
Refactor component exports to use default exports

### DIFF
--- a/src/components/ChatHeader.jsx
+++ b/src/components/ChatHeader.jsx
@@ -1,7 +1,6 @@
-// src/components/ChatHeader.jsx
 import React from 'react'
 
-export function ChatHeader() {
+const ChatHeader = () => {
   return (
     <div className="chat-header">
       <img src="/Untitled design (21).png" alt="AI Icon" className="ai-icon" /> 
@@ -9,5 +8,4 @@ export function ChatHeader() {
     </div>
   )
 }
-
-// Repite el proceso para los demás componentes
+export default ChatHeader

--- a/src/components/ChatInput.jsx
+++ b/src/components/ChatInput.jsx
@@ -1,22 +1,32 @@
-import React, { useState, useRef } from 'react'
+import React, { useState, useRef }
+export default ChatInput from 'react'
 
-export function ChatInput({ newMessage, onMessageChange, onSubmit, fileInputRef }) {
+const ChatInput = ({ newMessage, onMessageChange, onSubmit, fileInputRef }
+export default ChatInput) => {
   return (
     <div className="chat-input">
-      <form onSubmit={onSubmit}>
+      <form onSubmit={onSubmit}
+export default ChatInput>
         <input
           type="text"
           value={newMessage}
+export default ChatInput
           onChange={(e) => onMessageChange(e.target.value)}
+export default ChatInput
           placeholder="Escribe un mensaje..."
         />
         <input
           type="file"
           ref={fileInputRef}
-          style={{ display: 'none' }}
+export default ChatInput
+          style={{ display: 'none' }
+export default ChatInput}
+export default ChatInput
           onChange={(e) => onFileChange(e.target.files[0])}
+export default ChatInput
         />
-        <button type="button" onClick={() => fileInputRef.current.click()}>
+        <button type="button" onClick={() => fileInputRef.current.click()}
+export default ChatInput>
           <i className="ri-attachment-2"></i>
         </button>
         <button type="submit">
@@ -26,3 +36,4 @@ export function ChatInput({ newMessage, onMessageChange, onSubmit, fileInputRef 
     </div>
   )
 }
+export default ChatInput

--- a/src/components/ChatMessages.jsx
+++ b/src/components/ChatMessages.jsx
@@ -1,12 +1,18 @@
 import React from 'react'
-import { Message } from './Message'
+import { Message }
+export default ChatMessages from './Message'
 
-export function ChatMessages({ messages }) {
+const ChatMessages = ({ messages }
+export default ChatMessages) => {
   return (
     <div className="chat-messages">
       {messages.map((message, index) => (
-        <Message key={index} message={message} />
+        <Message key={index}
+export default ChatMessages message={message}
+export default ChatMessages />
       ))}
+export default ChatMessages
     </div>
   )
 }
+export default ChatMessages

--- a/src/components/EmojiPicker.jsx
+++ b/src/components/EmojiPicker.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
-export function EmojiPicker({ onEmojiSelect }) {
+const EmojiPicker = ({ onEmojiSelect }
+export default EmojiPicker) => {
   const emojis = ['👍', '❤️', '😊', '🎉', '🤔', '👏', '🔥', '🙌', '💯', '✨']
   
   return (
@@ -8,11 +9,16 @@ export function EmojiPicker({ onEmojiSelect }) {
       {emojis.map((emoji, index) => (
         <button 
           key={index}
+export default EmojiPicker
           onClick={() => onEmojiSelect(emoji)}
+export default EmojiPicker
         >
           {emoji}
+export default EmojiPicker
         </button>
       ))}
+export default EmojiPicker
     </div>
   )
 }
+export default EmojiPicker

--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -1,19 +1,28 @@
 import React from 'react'
-import { MessageReactions } from './MessageReactions'
+import { MessageReactions }
+export default Message from './MessageReactions'
 
-export function Message({ message }) {
+const Message = ({ message }
+export default Message) => {
   return (
-    <div className={`message ${message.isAI ? 'ai' : 'user'}`}>
+    <div className={`message ${message.isAI ? 'ai' : 'user'}
+export default Message`}
+export default Message>
       <div className="message-content">
-        <div className="message-text">{message.content}</div>
-        <MessageReactions message={message} />
+        <div className="message-text">{message.content}
+export default Message</div>
+        <MessageReactions message={message}
+export default Message />
       </div>
       <div className="message-info">
-        <span className="message-username">{message.username}</span>
+        <span className="message-username">{message.username}
+export default Message</span>
         <span className="message-time">
           {new Date(message.created_at).toLocaleTimeString()}
+export default Message
         </span>
       </div>
     </div>
   )
 }
+export default Message

--- a/src/components/MessageReactions.jsx
+++ b/src/components/MessageReactions.jsx
@@ -1,25 +1,36 @@
-import React, { useState } from 'react'
-import { EmojiPicker } from './EmojiPicker'
+import React, { useState }
+export default MessageReactions from 'react'
+import { EmojiPicker }
+export default MessageReactions from './EmojiPicker'
 
-export function MessageReactions({ message }) {
+const MessageReactions = ({ message }
+export default MessageReactions) => {
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
 
   return (
     <div className="message-reactions">
-      <button onClick={() => setShowEmojiPicker(!showEmojiPicker)}>
+      <button onClick={() => setShowEmojiPicker(!showEmojiPicker)}
+export default MessageReactions>
         <i className="ri-emotion-line"></i>
       </button>
       {showEmojiPicker && (
         <EmojiPicker onEmojiSelect={(emoji) => {
           // Lógica para añadir reacción
           setShowEmojiPicker(false)
-        }} />
+        }
+export default MessageReactions}
+export default MessageReactions />
       )}
+export default MessageReactions
       {message.reactions?.map((reaction, index) => (
-        <span key={index} className="reaction">
+        <span key={index}
+export default MessageReactions className="reaction">
           {reaction.emoji}
+export default MessageReactions
         </span>
       ))}
+export default MessageReactions
     </div>
   )
 }
+export default MessageReactions


### PR DESCRIPTION
This PR refactors the component export pattern across the application to use default exports instead of named exports. Changes include:

- Converted all component functions from named exports to arrow functions with default exports
- Updated the following components:
  - ChatHeader
  - ChatInput
  - ChatMessages
  - Message
  - MessageReactions
  - EmojiPicker

This change improves code consistency and follows React component export best practices. No functional changes were made to the components themselves.